### PR TITLE
CI: Add on-push a step to run all the tests

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,0 +1,28 @@
+name: Python run tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Setup.py
+        run: |
+          python -m setup build_ext --inplace
+      - name: Tests
+        run: |
+          python3 -m unittest persistable/test/test_persistable.py


### PR DESCRIPTION
This PR adds a check on every push that would install python and pip packages, run setup and run then the tests available.

Check that it works: https://github.com/manuelF/persistable/actions/runs/2683132270