### PR TITLE
perf: use two different metric trees for nn and mst, and add faster subsampling for Euclidean data

### DIFF
--- a/persistable/borrowed/_hdbscan_boruvka.pxd
+++ b/persistable/borrowed/_hdbscan_boruvka.pxd
@@ -18,15 +18,6 @@ cdef class BoruvkaUnionFind (object):
     cdef np.uint8_t[::1] _rank
     cdef np.ndarray is_component
 
-    #def __init__(self, size):
-    #    self._parent_arr = np.arange(size, dtype=np.intp)
-    #    self._parent = (<np.intp_t[:size:1]> (<np.intp_t *>
-    #                                          self._parent_arr.data))
-    #    self._rank_arr = np.zeros(size, dtype=np.uint8)
-    #    self._rank = (<np.uint8_t[:size:1]> (<np.uint8_t *>
-    #                                         self._rank_arr.data))
-    #    self.is_component = np.ones(size, dtype=bool)
-
     cpdef int union_(self, np.intp_t x, np.intp_t y) except -1
 
     cpdef np.intp_t find(self, np.intp_t x) except -1

--- a/persistable/borrowed/_hdbscan_boruvka.pyx
+++ b/persistable/borrowed/_hdbscan_boruvka.pyx
@@ -253,7 +253,7 @@ cdef class KDTreeBoruvkaAlgorithm (object):
     cdef const np.int_t[:, ::1] nn
     ####
 
-    def __init__(self, tree, core_distance, const np.int_t[:, ::1] nn, metric='euclidean', leaf_size=20, approx_min_span_tree=False, **kwargs):
+    def __init__(self, tree, core_distance, const np.int_t[:, ::1] nn, metric='euclidean', approx_min_span_tree=False, **kwargs):
 
         self.tree = tree
         self._data = np.array(self.tree.data)
@@ -793,7 +793,7 @@ cdef class BallTreeBoruvkaAlgorithm (object):
 
     cdef const np.int_t[:, ::1] nn
 
-    def __init__(self, tree, core_distance, const np.int_t[:,::1] nn, metric='euclidean', leaf_size=20, approx_min_span_tree=False,
+    def __init__(self, tree, core_distance, const np.int_t[:,::1] nn, metric='euclidean', approx_min_span_tree=False,
                  **kwargs):
 
         self.tree = tree

--- a/persistable/persistable_interactive.py
+++ b/persistable/persistable_interactive.py
@@ -256,8 +256,9 @@ class PersistableInteractive:
 
             return port
 
-    def cluster(self, **kwargs):
-        """Clusters the dataset passed to ``Persistable`` at initialization.
+    def cluster(self, propagate_labels=False, n_iterations_propagate_labels=30, n_neighbors_propagate_labels=15, **kwargs):
+        """Clusters the dataset with which the Persistable instance that was
+        passed through ``run_with`` was initialized.
 
         ``**kwargs``:
             Passed to ``Persistable.cluster``.
@@ -275,7 +276,9 @@ class PersistableInteractive:
                 "No parameters where chosen. Please use the graphical user interface to choose parameters."
             )
         else:
-            return self._persistable.cluster(**params, **kwargs)
+            return self._persistable.cluster(**params, propagate_labels=propagate_labels,
+                n_iterations_propagate_labels=n_iterations_propagate_labels,
+                n_neighbors_propagate_labels=n_neighbors_propagate_labels, **kwargs)
 
     def _chosen_parameters(self):
         self._parameters_sem.acquire()
@@ -291,9 +294,9 @@ class PersistableInteractive:
         default_min_s = 0
         default_max_s = end[0]
         # default_s_step = (default_max_s - default_min_s) / 100
-        default_granularity_ccf = 100
-        default_granularity_ri = 20
-        default_granularity_pv = 40
+        default_granularity_ccf = self._persistable._default_granularity()
+        default_granularity_ri = default_granularity_ccf // 5
+        default_granularity_pv =  default_granularity_ccf // 2
         default_num_jobs = 1
         default_max_dim = 15
         default_max_vines = 15
@@ -2123,11 +2126,18 @@ class PersistableInteractive:
             cancel=[[STOP_COMPUTE_CCF_BUTTON, N_CLICKS]],
         )
         def compute_ccf(d):
-            if debug:
-                print("Compute ccf in background started.")
 
             granularity = d[INPUT_GRANULARITY_CCF + VALUE]
             num_jobs = int(d[INPUT_NUM_JOBS_CCF + VALUE])
+
+            if debug:
+                print("Compute ccf in background started with inputs ",
+                    d[MIN_DIST_SCALE + VALUE],
+                    d[MAX_DIST_SCALE + VALUE],
+                    d[MAX_DENSITY_THRESHOLD + VALUE],
+                    d[MIN_DENSITY_THRESHOLD + VALUE],
+                    granularity,
+                    num_jobs)
 
             out = ""
             with warnings.catch_warnings(record=True) as w:

--- a/persistable/subsampling.pyx
+++ b/persistable/subsampling.pyx
@@ -56,7 +56,8 @@ cpdef close_subsample_distance_matrix(
 
     radii_view[-1] = np.max(ds)
 
-    return idx_perm, radii, representatives
+    return idx_perm, representatives
+    #return idx_perm, radii, representatives
 
 
 cpdef close_subsample_fast_metric(
@@ -115,4 +116,5 @@ cpdef close_subsample_fast_metric(
 
     radii_view[-1] = np.max(ds)
 
-    return idx_perm, radii, representatives
+    return idx_perm, representatives
+    #return idx_perm, radii, representatives

--- a/persistable/test/test_persistable.py
+++ b/persistable/test/test_persistable.py
@@ -343,13 +343,12 @@ class TestMetricSpace(unittest.TestCase):
     X = make_blobs(n_samples=1000, n_features=2, centers=3, random_state=6, cluster_std=1.5)[0]
     dm = distance_matrix(X, X, p=2)
     ms = _MetricSpace(dm, "precomputed")
-    Y, radii, reps = ms.close_subsample(100, seed=0)
+    Y, reps = ms.close_subsample(100, seed=0)
 
     ms2 = _MetricSpace(X, metric="minkowski")
-    Y2, radii2, reps2 = ms2.close_subsample(100, seed=0)
+    Y2, reps2 = ms2.close_subsample(100, seed=0)
 
     np.testing.assert_array_equal(Y,Y2)
-    np.testing.assert_array_equal(radii,radii2)
     np.testing.assert_array_equal(reps,reps2)
 
 


### PR DESCRIPTION
* use different trees for nn_fit and for spanning tree computation

* better defaults for granularity for large data

* add fast subsampling for euclidean data